### PR TITLE
Implemented a retention check for audit trail entries (fixes #27).

### DIFF
--- a/src/main/java/org/trustdeck/configuration/AuditTrailRetentionConfiguration.java
+++ b/src/main/java/org/trustdeck/configuration/AuditTrailRetentionConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Trust Deck Services
+ * Copyright 2025 Armin Müller and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trustdeck.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Data;
+
+/**
+ * Configuration for the periodic cleanup of the audit trail table.
+ *
+ * @author Armin Müller
+ */
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "audittrail.cleanup")
+public class AuditTrailRetentionConfiguration {
+	
+	/** Whether the periodic cleanup of the audittrail is enabled.*/
+	private boolean enabled = true;
+
+	/** The cron expression for scheduling the cleanup task. Default is every day at 2:00 AM. */
+	private String cron = "0 0 2 * * ?";
+
+	/** The retention period in days. Audit entries older than this will be deleted. Default is 3650 days (approximately 10 years).*/
+	private int retentionDays = 730;
+}

--- a/src/main/java/org/trustdeck/security/audittrail/AuditTrailRetentionService.java
+++ b/src/main/java/org/trustdeck/security/audittrail/AuditTrailRetentionService.java
@@ -1,0 +1,86 @@
+/*
+ * Trust Deck Services
+ * Copyright 2025 Armin Müller and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trustdeck.security.audittrail;
+
+import java.time.DateTimeException;
+import java.time.LocalDateTime;
+
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.trustdeck.configuration.AuditTrailRetentionConfiguration;
+
+import static org.trustdeck.jooq.generated.Tables.AUDITEVENT;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This service is responsible for periodically cleaning up old entries in the
+ * audit trail database table.
+ *
+ * @author Armin Müller
+ */
+@Service
+@Slf4j
+public class AuditTrailRetentionService {
+
+	/** The jOOQ DSL context for database interaction. */
+	@Autowired
+	private DSLContext dslCtx;
+
+	/** The configuration for the audit trail cleanup. */
+	@Autowired
+	private AuditTrailRetentionConfiguration retentionConfig;
+
+	/**
+	 * Periodically cleans up old audit trail entries based on the configured
+	 * retention period. The schedule is defined by a cron expression in the
+	 * application configuration.
+	 */
+	@Scheduled(cron = "${audittrail.cleanup.cron}")
+	public void cleanupOldAuditEntries() {
+		// Check if periodic cleaning is enabled
+		if (!retentionConfig.isEnabled()) {
+			log.debug("AuditTrail cleanup is disabled. Skipping task.");
+			return;
+		}
+
+		log.info("Starting scheduled cleanup of old audit trail entries...");
+
+		try {
+			LocalDateTime cutoffDateTime = LocalDateTime.now().minusDays(retentionConfig.getRetentionDays());
+			log.trace("Deleting audit trail entries older than " + cutoffDateTime + ".");
+
+			int deletedRows = dslCtx.transactionResult(configuration ->
+				DSL.using(configuration)
+				.deleteFrom(AUDITEVENT)
+				.where(AUDITEVENT.REQUESTTIME.lt(cutoffDateTime))
+				.execute());
+
+			log.info("Successfully deleted " + deletedRows + " old audit trail entries.");
+		} catch (DateTimeException e) {
+			log.error("Could not determine cutoff date.", e);
+		} catch (DataAccessException f) {
+			log.error("Deleting old audit trail entries failed due to a database issue: ", f);
+		} catch (RuntimeException g) {
+			log.error("Error occurred during audit trail cleanup task.", g);
+		}
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,6 +57,12 @@ audittrail:
       isTechnical: Technical
       isNoAuditing: Unaudited
       isAuditEverything: AuditEverything
+  cleanup:
+    enabled: true
+    # Cron expression for cleanup task. Default: Every day at 2:00 AM.
+    cron: "0 0 2 * * ?"
+    # Retention period in days for audit entries.
+    retention-days: 3650
 
 app:
   response:


### PR DESCRIPTION
Implemented a retention check for audit trail entries (fixes #27). Old entries will be removed after a certain time. Checking for this is donw with a cron-job-like periodic check.